### PR TITLE
Allow `data_prefix` to be None when mocking dataset

### DIFF
--- a/nemo/collections/nlp/data/language_modeling/megatron/gpt_dataset.py
+++ b/nemo/collections/nlp/data/language_modeling/megatron/gpt_dataset.py
@@ -94,7 +94,7 @@ def build_train_valid_test_datasets(
 ):
     if data_impl in ['mock']:
         logging.info('Initializing mock GPT dataset for train, validate, and test')
-        if len(data_prefix) != 0:
+        if data_prefix is not None and len(data_prefix) != 0:
             # Mock data will be generated instead of loading files.
             logging.warning(f"Requested data_impl={data_impl}, so ignoring data_prefix setting: {data_prefix}")
         if tokenizer is None:


### PR DESCRIPTION
# What does this PR do ?

Allow `data_prefix` to be None when mocking dataset, i.e., allow the following config
```yaml
    data_prefix: null
    data_impl: mock
```

Without this change, it will throw en error saying that `None` type doesn't support the `len()` method.

**Collection**: [NLP]

# Changelog 
- nemo/collections/nlp/data/language_modeling/megatron/gpt_dataset.py

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
